### PR TITLE
Close the socket after we have timed out

### DIFF
--- a/custom_components/lightwaverf_energy/sensor.py
+++ b/custom_components/lightwaverf_energy/sensor.py
@@ -70,6 +70,7 @@ class LightwaveEnergy(Entity):
                 self.current_usage = self.lightwave_energy_data.get("cUse")
                 self.today_usage = self.lightwave_energy_data.get("todUse")
                 _LOGGER.debug("Lightwave_Energy skipping update")
+            sock.close()
             self._updatets = time.time()
         else:
             _LOGGER.info("Lightwave_Energy skipping update")


### PR DESCRIPTION
Fixes #7 

This PR closes the socket after we've done the check for data and processed the data, resetting the connection for the next time we run.

The "address in use" error no longer appears in my logs.

I'm still not getting any data, but I suspect that's down to my own setup rather than an issue with the code.